### PR TITLE
Multi language first (and naive) approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Or install it yourself as:
     AfterTheDeadline.check "My last name, Sepcot, is very unique."
     => []
 
+## Multilanguage
+
+After the deadline service provides 5 languages:
+
+* English (en, default)
+* French (fr)
+* German (de)
+* Spanish (es)
+* Portuguese (pt)
+
+If no language is set English is choosen by default. To set another language simply set it:
+
+    AfterTheDeadline.set_language('de') # possible values en, fr, de, es, pt
+
 ## Contributing
 
 1. Fork it

--- a/after_the_deadline.gemspec
+++ b/after_the_deadline.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'after_the_deadline'
-  spec.version       = '0.1.2'
+  spec.version       = '0.1.3'
   spec.authors       = ['Michael J. Sepcot']
   spec.email         = ['developer@sepcot.com']
   spec.description   = %q{A ruby library for working with the After The Deadline service.}


### PR DESCRIPTION
I tried to follow your coding standards for this project. This is a naive approach to multi language. When migrating to ruby 2.0 named parameters could be used in the `AfterTheDeadline()` to allow for partial configuration.
